### PR TITLE
fix: support Windows MCP working directories

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15070,8 +15070,9 @@ function McpServerForm(props) {
     actions.setTestRunning(true);
     try {
       actions.setTest(await injected.test(draft));
-    } catch {
+    } catch (error) {
       actions.setTest(null);
+      setSaveError(error instanceof Error ? error.message : String(error));
     } finally {
       actions.setTestRunning(false);
     }
@@ -15082,13 +15083,13 @@ function McpServerForm(props) {
     try {
       const failure = await injected.save(draft);
       if (failure !== null) {
-        setSaveError(t(failureLocaleKey(failure.code)));
+        setSaveError(`${failure.code}: ${failure.message}`);
         return;
       }
       await refresh();
       actions.cancelEdit();
-    } catch {
-      setSaveError(t("failureTitle"));
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : String(error));
     } finally {
       actions.setBusy(null);
     }
@@ -15105,17 +15106,14 @@ function McpServerForm(props) {
       }
       await refresh();
       actions.cancelEdit();
-    } catch {
-      setSaveError(t("failureTitle"));
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : String(error));
     } finally {
       actions.setBusy(null);
     }
   };
   const refresh = async () => {
-    try {
-      actions.setServers(await injected.list());
-    } catch {
-    }
+    actions.setServers(await injected.list());
   };
   const stdio = draft.transport === "stdio";
   const probe = test?.probe;

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ function validateServerInput(server, env) {
 	if (!serverNameSchema.safeParse(server.serverName).success) throw new McpServerValidationError("serverName must match [A-Za-z0-9_-]{1,32}");
 	if (server.transport === "stdio") {
 		if (server.command.trim().length === 0) throw new McpServerValidationError("stdio transport requires a command");
-		if (server.cwd.length > 0 && !/^[/\\]/.test(server.cwd)) throw new McpServerValidationError("cwd must be an absolute path or empty");
+		if (server.cwd.length > 0 && !/^(?:[A-Za-z]:[\\/]|[/\\])/.test(server.cwd)) throw new McpServerValidationError("cwd must be an absolute path or empty");
 	} else try {
 		const parsed = new URL(server.url);
 		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("non-http protocol");

--- a/src/client/ServerForm.tsx
+++ b/src/client/ServerForm.tsx
@@ -3,7 +3,7 @@ import type { McpServerId, McpServerView } from './types.ts'
 import type {
   McpDraft, McpEnvRowDraft, McpTestOutcome,
 } from './mcp-store.ts'
-import { createEnvRowDraft, failureLocaleKey } from './mcp-store.ts'
+import { createEnvRowDraft } from './mcp-store.ts'
 import type { McpSettingsLocaleKey } from './locales.ts'
 import css from './ServerForm.module.css'
 
@@ -63,8 +63,9 @@ export function McpServerForm(props: McpServerFormProps): ReactNode {
     actions.setTestRunning(true)
     try {
       actions.setTest(await injected.test(draft))
-    } catch {
+    } catch (error) {
       actions.setTest(null)
+      setSaveError(error instanceof Error ? error.message : String(error))
     } finally {
       actions.setTestRunning(false)
     }
@@ -76,13 +77,13 @@ export function McpServerForm(props: McpServerFormProps): ReactNode {
     try {
       const failure = await injected.save(draft)
       if (failure !== null) {
-        setSaveError(t(failureLocaleKey(failure.code)))
+        setSaveError(`${failure.code}: ${failure.message}`)
         return
       }
       await refresh()
       actions.cancelEdit()
-    } catch {
-      setSaveError(t('failureTitle'))
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : String(error))
     } finally {
       actions.setBusy(null)
     }
@@ -100,20 +101,15 @@ export function McpServerForm(props: McpServerFormProps): ReactNode {
       }
       await refresh()
       actions.cancelEdit()
-    } catch {
-      setSaveError(t('failureTitle'))
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : String(error))
     } finally {
       actions.setBusy(null)
     }
   }
 
   const refresh = async (): Promise<void> => {
-    try {
-      actions.setServers(await injected.list())
-    } catch {
-      // The save/remove outcome is the actionable one; a failed refresh is
-      // re-run on the next page visit.
-    }
+    actions.setServers(await injected.list())
   }
 
   const stdio = draft.transport === 'stdio'


### PR DESCRIPTION
## Summary
- accept drive-letter absolute paths for stdio MCP working directories
- surface real Remote errors from save, refresh, test, and delete operations
- keep the checked-in browser bundle aligned with the TypeScript source

## Verification
- 
ode --check lib/index.js`n- 
ode --check lib/client.js`n- verified D:\\gitclone\\openai-websearch-mcp-modern is accepted while relative paths remain rejected
- manually configured and connected a Windows-path stdio MCP server