### PR TITLE
fix: support Windows MCP working directories

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -27,7 +27,7 @@ __export(index_exports, {
 });
 module.exports = __toCommonJS(index_exports);
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/external.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/external.js
 var external_exports = {};
 __export(external_exports, {
   $brand: () => $brand,
@@ -270,7 +270,7 @@ __export(external_exports, {
   xor: () => xor
 });
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/index.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/index.js
 var core_exports2 = {};
 __export(core_exports2, {
   $ZodAny: () => $ZodAny,
@@ -549,7 +549,7 @@ __export(core_exports2, {
   version: () => version
 });
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/core.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/core.js
 var _a;
 var NEVER = /* @__PURE__ */ Object.freeze({
   status: "aborted"
@@ -626,7 +626,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/util.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -1322,7 +1322,7 @@ var Class = class {
   }
 };
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/errors.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -1461,7 +1461,7 @@ function prettifyError(error51) {
   return lines.join("\n");
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/parse.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -1549,7 +1549,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
 };
 var safeDecodeAsync = /* @__PURE__ */ _safeDecodeAsync($ZodRealError);
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/regexes.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/regexes.js
 var regexes_exports = {};
 __export(regexes_exports, {
   base64: () => base64,
@@ -1708,7 +1708,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/checks.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a3;
   inst._zod ?? (inst._zod = {});
@@ -2256,7 +2256,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/doc.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -2292,14 +2292,14 @@ var Doc = class {
   }
 };
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/versions.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 4,
   patch: 3
 };
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/schemas.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a3;
   inst ?? (inst = {});
@@ -4392,7 +4392,7 @@ function handleRefineResult(result, payload, input, inst) {
   }
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/index.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/index.js
 var locales_exports = {};
 __export(locales_exports, {
   ar: () => ar_default,
@@ -4449,7 +4449,7 @@ __export(locales_exports, {
   zhTW: () => zh_TW_default
 });
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ar.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ar.js
 var error = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -4556,7 +4556,7 @@ function ar_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/az.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/az.js
 var error2 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
@@ -4662,7 +4662,7 @@ function az_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/be.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/be.js
 function getBelarusianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -4819,7 +4819,7 @@ function be_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/bg.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/bg.js
 var error4 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0430", verb: "\u0434\u0430 \u0441\u044A\u0434\u044A\u0440\u0436\u0430" },
@@ -4940,7 +4940,7 @@ function bg_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ca.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ca.js
 var error5 = () => {
   const Sizable = {
     string: { unit: "car\xE0cters", verb: "contenir" },
@@ -5049,7 +5049,7 @@ function ca_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/cs.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/cs.js
 var error6 = () => {
   const Sizable = {
     string: { unit: "znak\u016F", verb: "m\xEDt" },
@@ -5161,7 +5161,7 @@ function cs_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/da.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/da.js
 var error7 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
@@ -5277,7 +5277,7 @@ function da_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/de.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/de.js
 var error8 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
@@ -5386,7 +5386,7 @@ function de_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/el.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/el.js
 var error9 = () => {
   const Sizable = {
     string: { unit: "\u03C7\u03B1\u03C1\u03B1\u03BA\u03C4\u03AE\u03C1\u03B5\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
@@ -5496,7 +5496,7 @@ function el_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/en.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/en.js
 var error10 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -5609,7 +5609,7 @@ function en_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/eo.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/eo.js
 var error11 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
@@ -5719,7 +5719,7 @@ function eo_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/es.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/es.js
 var error12 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
@@ -5852,7 +5852,7 @@ function es_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/fa.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/fa.js
 var error13 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -5967,7 +5967,7 @@ function fa_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/fi.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/fi.js
 var error14 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
@@ -6080,7 +6080,7 @@ function fi_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/fr.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/fr.js
 var error15 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
@@ -6206,7 +6206,7 @@ function fr_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/fr-CA.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/fr-CA.js
 var error16 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
@@ -6314,7 +6314,7 @@ function fr_CA_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/he.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/he.js
 var error17 = () => {
   const TypeNames = {
     string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
@@ -6509,7 +6509,7 @@ function he_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/hr.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/hr.js
 var error18 = () => {
   const Sizable = {
     string: { unit: "znakova", verb: "imati" },
@@ -6632,7 +6632,7 @@ function hr_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/hu.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/hu.js
 var error19 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
@@ -6741,7 +6741,7 @@ function hu_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/hy.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/hy.js
 function getArmenianPlural(count, one, many) {
   return Math.abs(count) === 1 ? one : many;
 }
@@ -6889,7 +6889,7 @@ function hy_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/id.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/id.js
 var error21 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
@@ -6996,7 +6996,7 @@ function id_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/is.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/is.js
 var error22 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
@@ -7106,7 +7106,7 @@ function is_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/it.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/it.js
 var error23 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
@@ -7215,7 +7215,7 @@ function it_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ja.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ja.js
 var error24 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
@@ -7323,7 +7323,7 @@ function ja_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ka.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ka.js
 var error25 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -7436,7 +7436,7 @@ function ka_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/km.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/km.js
 var error26 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -7547,12 +7547,12 @@ function km_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/kh.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/kh.js
 function kh_default() {
   return km_default();
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ko.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ko.js
 var error27 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
@@ -7664,7 +7664,7 @@ function ko_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/lt.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/lt.js
 var capitalizeFirstCharacter = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
 };
@@ -7868,7 +7868,7 @@ function lt_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/mk.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/mk.js
 var error29 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -7978,7 +7978,7 @@ function mk_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ms.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ms.js
 var error30 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
@@ -8086,7 +8086,7 @@ function ms_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/nl.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/nl.js
 var error31 = () => {
   const Sizable = {
     string: { unit: "tekens", verb: "heeft" },
@@ -8197,7 +8197,7 @@ function nl_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/no.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/no.js
 var error32 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
@@ -8306,7 +8306,7 @@ function no_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ota.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ota.js
 var error33 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
@@ -8416,7 +8416,7 @@ function ota_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ps.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ps.js
 var error34 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
@@ -8531,7 +8531,7 @@ function ps_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/pl.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/pl.js
 var error35 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
@@ -8641,7 +8641,7 @@ function pl_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/pt.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/pt.js
 var error36 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
@@ -8750,7 +8750,7 @@ function pt_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ro.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ro.js
 var error37 = () => {
   const Sizable = {
     string: { unit: "caractere", verb: "s\u0103 aib\u0103" },
@@ -8870,7 +8870,7 @@ function ro_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ru.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -9027,7 +9027,7 @@ function ru_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/sl.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/sl.js
 var error39 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
@@ -9137,7 +9137,7 @@ function sl_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/sv.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/sv.js
 var error40 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
@@ -9248,7 +9248,7 @@ function sv_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ta.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ta.js
 var error41 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -9359,7 +9359,7 @@ function ta_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/th.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/th.js
 var error42 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -9470,7 +9470,7 @@ function th_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/tr.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/tr.js
 var error43 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
@@ -9576,7 +9576,7 @@ function tr_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/uk.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/uk.js
 var error44 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -9685,12 +9685,12 @@ function uk_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ua.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ua.js
 function ua_default() {
   return uk_default();
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/ur.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/ur.js
 var error45 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
@@ -9801,7 +9801,7 @@ function ur_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/uz.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/uz.js
 var error46 = () => {
   const Sizable = {
     string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
@@ -9912,7 +9912,7 @@ function uz_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/vi.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/vi.js
 var error47 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
@@ -10021,7 +10021,7 @@ function vi_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/zh-CN.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/zh-CN.js
 var error48 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
@@ -10131,7 +10131,7 @@ function zh_CN_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/zh-TW.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/zh-TW.js
 var error49 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
@@ -10239,7 +10239,7 @@ function zh_TW_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/locales/yo.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/locales/yo.js
 var error50 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
@@ -10347,7 +10347,7 @@ function yo_default() {
   };
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/registries.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/registries.js
 var _a2;
 var $output = /* @__PURE__ */ Symbol("ZodOutput");
 var $input = /* @__PURE__ */ Symbol("ZodInput");
@@ -10397,7 +10397,7 @@ function registry() {
 (_a2 = globalThis).__zod_globalRegistry ?? (_a2.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/api.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -11436,7 +11436,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   return inst;
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/to-json-schema.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -11795,7 +11795,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/json-schema-processors.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -12339,7 +12339,7 @@ function toJSONSchema(input, params) {
   return finalize(ctx, input);
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/json-schema-generator.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/json-schema-generator.js
 var JSONSchemaGenerator = class {
   /** @deprecated Access via ctx instead */
   get metadataRegistry() {
@@ -12414,10 +12414,10 @@ var JSONSchemaGenerator = class {
   }
 };
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/json-schema.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/core/json-schema.js
 var json_schema_exports = {};
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/schemas.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/schemas.js
 var schemas_exports2 = {};
 __export(schemas_exports2, {
   ZodAny: () => ZodAny,
@@ -12588,7 +12588,7 @@ __export(schemas_exports2, {
   xor: () => xor
 });
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/checks.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/checks.js
 var checks_exports2 = {};
 __export(checks_exports2, {
   endsWith: () => _endsWith,
@@ -12622,7 +12622,7 @@ __export(checks_exports2, {
   uppercase: () => _uppercase
 });
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/iso.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/iso.js
 var iso_exports = {};
 __export(iso_exports, {
   ZodISODate: () => ZodISODate,
@@ -12663,7 +12663,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/errors.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -12703,7 +12703,7 @@ var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/parse.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse2 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -12717,7 +12717,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/schemas.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/schemas.js
 var _installedGroups = /* @__PURE__ */ new WeakMap();
 function _installLazyMethods(inst, group, methods) {
   const proto = Object.getPrototypeOf(inst);
@@ -14007,7 +14007,7 @@ function preprocess(fn, schema) {
   });
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/compat.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/compat.js
 var ZodIssueCode = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -14033,7 +14033,7 @@ var ZodFirstPartyTypeKind;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind2) {
 })(ZodFirstPartyTypeKind || (ZodFirstPartyTypeKind = {}));
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/from-json-schema.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/from-json-schema.js
 var z = {
   ...schemas_exports2,
   ...checks_exports2,
@@ -14513,7 +14513,7 @@ function fromJSONSchema(schema, params) {
   return convertSchema(normalized, ctx);
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/coerce.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/coerce.js
 var coerce_exports = {};
 __export(coerce_exports, {
   bigint: () => bigint3,
@@ -14538,7 +14538,7 @@ function date4(params) {
   return _coercedDate(ZodDate, params);
 }
 
-// ../../deepseek-harness/node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/classic/external.js
+// C:/Users/Alice/AppData/Roaming/npm/node_modules/@deepseek-ai/dsh/node_modules/zod/v4/classic/external.js
 config(en_default());
 
 // src/client/remote-contribution.js
@@ -14971,20 +14971,6 @@ function draftToSubmission(draft) {
     }))
   };
 }
-function failureLocaleKey(code) {
-  switch (code) {
-    case "MCP_SERVER_NAME_CONFLICT":
-      return "serverNameConflict";
-    case "MCP_SERVER_NOT_FOUND":
-      return "notFound";
-    case "MCP_INVALID_SPEC":
-      return "invalidSpec";
-    case "MCP_MOUNT_FAILED":
-      return "mountFailed";
-    default:
-      return "failureTitle";
-  }
-}
 function createMcpManagerStore() {
   return (0, import_client.defineStore)({
     init: () => ({
@@ -15035,12 +15021,12 @@ function createMcpManagerStore() {
 // src/client/ServerForm.module.css
 (function() {
   if (typeof document !== "undefined") {
-    const existing = document.querySelector('style[data-plugin="dsh-mcp"][data-file="ServerForm.module.css"]');
+    const existing = document.querySelector('style[data-plugin="dsh-mcp"][data-file="D:Gitclonedsh-mcp-manager-comparisonArvinQi__dsh-mcpsrcclientServerForm.module.css"]');
     if (!existing) {
       const style = document.createElement("style");
       style.setAttribute("data-plugin", "dsh-mcp");
-      style.setAttribute("data-file", "ServerForm.module.css");
-      style.textContent = ".form {\n  display: flex;\n  flex-direction: column;\n  gap: 14px;\n  width: 100%;\n  max-width: 760px;\n  color: var(--dsw-alias-label-primary);\n}\n\n.titleRow {\n  display: flex;\n  align-items: center;\n  justify-content: space-between;\n  gap: 12px;\n}\n\n.title {\n  margin: 0;\n  font-size: 15px;\n  line-height: 22px;\n  font-weight: 600;\n}\n\n.titleActions {\n  display: flex;\n  gap: 8px;\n}\n\nbutton {\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 6px;\n  padding: 5px 12px;\n  background: transparent;\n  color: var(--dsw-alias-label-primary);\n  font: inherit;\n  font-size: 13px;\n  line-height: 20px;\n  cursor: pointer;\n}\n\nbutton:hover {\n  background: var(--dsw-alias-interactive-bg-hover);\n}\n\nbutton:focus-visible {\n  outline: 2px solid var(--dsw-alias-brand-primary);\n  outline-offset: 1px;\n}\n\nbutton:disabled {\n  cursor: not-allowed;\n  opacity: 0.55;\n}\n\n.primary {\n  border-color: var(--dsw-alias-button-primary-fill);\n  background: var(--dsw-alias-button-primary-fill);\n  color: var(--dsw-alias-label-primary-foreground);\n}\n\n.primary:hover {\n  background: var(--dsw-alias-button-primary-hover);\n}\n\n.danger {\n  color: var(--dsw-alias-state-error-primary);\n}\n\n.error {\n  margin: 0;\n  color: var(--dsw-alias-state-error-primary);\n  font-size: 13px;\n  line-height: 20px;\n}\n\n.field {\n  display: flex;\n  flex-direction: column;\n  gap: 5px;\n  font-size: 13px;\n  line-height: 20px;\n  color: var(--dsw-alias-label-secondary);\n}\n\n.field input,\n.field select,\n.field textarea {\n  width: 100%;\n  box-sizing: border-box;\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 8px;\n  padding: 6px 10px;\n  outline: none;\n  background: var(--dsw-alias-bg-layer-1);\n  color: var(--dsw-alias-label-primary);\n  font: inherit;\n  font-size: 13px;\n  resize: vertical;\n}\n\n.field input::placeholder,\n.field textarea::placeholder {\n  color: var(--dsw-alias-label-tertiary);\n}\n\n.field input:focus-visible,\n.field select:focus-visible,\n.field textarea:focus-visible {\n  border-color: var(--dsw-alias-brand-primary);\n  box-shadow: 0 0 0 2px color-mix(in srgb, var(--dsw-alias-brand-primary) 18%, transparent);\n}\n\n.envBlock {\n  display: flex;\n  flex-direction: column;\n  gap: 8px;\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 10px;\n  padding: 10px 12px 12px;\n  margin: 0;\n}\n\n.envBlock legend {\n  padding: 0 4px;\n  font-size: 13px;\n  line-height: 20px;\n  font-weight: 600;\n}\n\n.hint,\n.muted {\n  margin: 0;\n  font-size: 12px;\n  line-height: 18px;\n  color: var(--dsw-alias-label-tertiary);\n}\n\n.envRow {\n  display: grid;\n  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.6fr) auto auto;\n  align-items: center;\n  gap: 8px;\n}\n\n.envRow input {\n  box-sizing: border-box;\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 6px;\n  padding: 5px 8px;\n  outline: none;\n  background: var(--dsw-alias-bg-layer-1);\n  color: var(--dsw-alias-label-primary);\n  font: inherit;\n  font-size: 13px;\n}\n\n.secretToggle {\n  display: inline-flex;\n  align-items: center;\n  gap: 4px;\n  color: var(--dsw-alias-label-secondary);\n  font-size: 12px;\n  line-height: 18px;\n  white-space: nowrap;\n  cursor: pointer;\n}\n\n.checkRow {\n  display: inline-flex;\n  align-items: center;\n  gap: 8px;\n  font-size: 13px;\n  line-height: 20px;\n  color: var(--dsw-alias-label-secondary);\n  cursor: pointer;\n}\n\n.testResult {\n  margin: 0;\n  font-size: 13px;\n  line-height: 20px;\n}\n\n.testOk {\n  color: var(--dsw-alias-state-success-primary);\n}\n\n.testFail {\n  color: var(--dsw-alias-state-error-primary);\n}\n\n.actions {\n  display: flex;\n  justify-content: flex-end;\n  gap: 8px;\n}\n";
+      style.setAttribute("data-file", "D:Gitclonedsh-mcp-manager-comparisonArvinQi__dsh-mcpsrcclientServerForm.module.css");
+      style.textContent = ".form {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 14px;\r\n  width: 100%;\r\n  max-width: 760px;\r\n  color: var(--dsw-alias-label-primary);\r\n}\r\n\r\n.titleRow {\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: space-between;\r\n  gap: 12px;\r\n}\r\n\r\n.title {\r\n  margin: 0;\r\n  font-size: 15px;\r\n  line-height: 22px;\r\n  font-weight: 600;\r\n}\r\n\r\n.titleActions {\r\n  display: flex;\r\n  gap: 8px;\r\n}\r\n\r\nbutton {\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 6px;\r\n  padding: 5px 12px;\r\n  background: transparent;\r\n  color: var(--dsw-alias-label-primary);\r\n  font: inherit;\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n  cursor: pointer;\r\n}\r\n\r\nbutton:hover {\r\n  background: var(--dsw-alias-interactive-bg-hover);\r\n}\r\n\r\nbutton:focus-visible {\r\n  outline: 2px solid var(--dsw-alias-brand-primary);\r\n  outline-offset: 1px;\r\n}\r\n\r\nbutton:disabled {\r\n  cursor: not-allowed;\r\n  opacity: 0.55;\r\n}\r\n\r\n.primary {\r\n  border-color: var(--dsw-alias-button-primary-fill);\r\n  background: var(--dsw-alias-button-primary-fill);\r\n  color: var(--dsw-alias-label-primary-foreground);\r\n}\r\n\r\n.primary:hover {\r\n  background: var(--dsw-alias-button-primary-hover);\r\n}\r\n\r\n.danger {\r\n  color: var(--dsw-alias-state-error-primary);\r\n}\r\n\r\n.error {\r\n  margin: 0;\r\n  color: var(--dsw-alias-state-error-primary);\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n}\r\n\r\n.field {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 5px;\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n  color: var(--dsw-alias-label-secondary);\r\n}\r\n\r\n.field input,\r\n.field select,\r\n.field textarea {\r\n  width: 100%;\r\n  box-sizing: border-box;\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 8px;\r\n  padding: 6px 10px;\r\n  outline: none;\r\n  background: var(--dsw-alias-bg-layer-1);\r\n  color: var(--dsw-alias-label-primary);\r\n  font: inherit;\r\n  font-size: 13px;\r\n  resize: vertical;\r\n}\r\n\r\n.field input::placeholder,\r\n.field textarea::placeholder {\r\n  color: var(--dsw-alias-label-tertiary);\r\n}\r\n\r\n.field input:focus-visible,\r\n.field select:focus-visible,\r\n.field textarea:focus-visible {\r\n  border-color: var(--dsw-alias-brand-primary);\r\n  box-shadow: 0 0 0 2px color-mix(in srgb, var(--dsw-alias-brand-primary) 18%, transparent);\r\n}\r\n\r\n.envBlock {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 8px;\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 10px;\r\n  padding: 10px 12px 12px;\r\n  margin: 0;\r\n}\r\n\r\n.envBlock legend {\r\n  padding: 0 4px;\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n  font-weight: 600;\r\n}\r\n\r\n.hint,\r\n.muted {\r\n  margin: 0;\r\n  font-size: 12px;\r\n  line-height: 18px;\r\n  color: var(--dsw-alias-label-tertiary);\r\n}\r\n\r\n.envRow {\r\n  display: grid;\r\n  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.6fr) auto auto;\r\n  align-items: center;\r\n  gap: 8px;\r\n}\r\n\r\n.envRow input {\r\n  box-sizing: border-box;\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 6px;\r\n  padding: 5px 8px;\r\n  outline: none;\r\n  background: var(--dsw-alias-bg-layer-1);\r\n  color: var(--dsw-alias-label-primary);\r\n  font: inherit;\r\n  font-size: 13px;\r\n}\r\n\r\n.secretToggle {\r\n  display: inline-flex;\r\n  align-items: center;\r\n  gap: 4px;\r\n  color: var(--dsw-alias-label-secondary);\r\n  font-size: 12px;\r\n  line-height: 18px;\r\n  white-space: nowrap;\r\n  cursor: pointer;\r\n}\r\n\r\n.checkRow {\r\n  display: inline-flex;\r\n  align-items: center;\r\n  gap: 8px;\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n  color: var(--dsw-alias-label-secondary);\r\n  cursor: pointer;\r\n}\r\n\r\n.testResult {\r\n  margin: 0;\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n}\r\n\r\n.testOk {\r\n  color: var(--dsw-alias-state-success-primary);\r\n}\r\n\r\n.testFail {\r\n  color: var(--dsw-alias-state-error-primary);\r\n}\r\n\r\n.actions {\r\n  display: flex;\r\n  justify-content: flex-end;\r\n  gap: 8px;\r\n}\r\n";
       document.head.appendChild(style);
     }
   }
@@ -15065,13 +15051,16 @@ function McpServerForm(props) {
   const addEnvRow = () => {
     update({ env: [...draft.env, createEnvRowDraft()] });
   };
+  const errorText = (error51) => error51 instanceof Error ? error51.message : String(error51);
   const runTest = async () => {
     setSaveError(null);
     actions.setTestRunning(true);
     try {
       actions.setTest(await injected.test(draft));
-    } catch {
+    } catch (error51) {
+      console.error("[dsh-mcp] test failed:", error51);
       actions.setTest(null);
+      setSaveError(errorText(error51));
     } finally {
       actions.setTestRunning(false);
     }
@@ -15082,14 +15071,15 @@ function McpServerForm(props) {
     try {
       const failure = await injected.save(draft);
       if (failure !== null) {
-        setSaveError(t(failureLocaleKey(failure.code)));
+        setSaveError(`${failure.code}: ${failure.message}`);
         return;
       }
-      await refresh();
+      if (!await refresh()) return;
       actions.cancelEdit();
       onSaved?.();
-    } catch {
-      setSaveError(t("failureTitle"));
+    } catch (error51) {
+      console.error("[dsh-mcp] save failed:", error51);
+      setSaveError(errorText(error51));
     } finally {
       actions.setBusy(null);
     }
@@ -15101,13 +15091,14 @@ function McpServerForm(props) {
     try {
       const failure = await injected.remove(draft.id);
       if (failure !== null) {
-        setSaveError(failure.message);
+        setSaveError(`${failure.code}: ${failure.message}`);
         return;
       }
-      await refresh();
+      if (!await refresh()) return;
       actions.cancelEdit();
-    } catch {
-      setSaveError(t("failureTitle"));
+    } catch (error51) {
+      console.error("[dsh-mcp] remove failed:", error51);
+      setSaveError(errorText(error51));
     } finally {
       actions.setBusy(null);
     }
@@ -15115,7 +15106,11 @@ function McpServerForm(props) {
   const refresh = async () => {
     try {
       actions.setServers(await injected.list());
-    } catch {
+      return true;
+    } catch (error51) {
+      console.error("[dsh-mcp] refresh failed:", error51);
+      setSaveError(errorText(error51));
+      return false;
     }
   };
   const stdio = draft.transport === "stdio";
@@ -15314,12 +15309,12 @@ function McpServerForm(props) {
 // src/client/McpSettingsSection.module.css
 (function() {
   if (typeof document !== "undefined") {
-    const existing = document.querySelector('style[data-plugin="dsh-mcp"][data-file="McpSettingsSection.module.css"]');
+    const existing = document.querySelector('style[data-plugin="dsh-mcp"][data-file="D:Gitclonedsh-mcp-manager-comparisonArvinQi__dsh-mcpsrcclientMcpSettingsSection.module.css"]');
     if (!existing) {
       const style = document.createElement("style");
       style.setAttribute("data-plugin", "dsh-mcp");
-      style.setAttribute("data-file", "McpSettingsSection.module.css");
-      style.textContent = ".section {\n  display: flex;\n  flex-direction: column;\n  gap: 14px;\n  width: 100%;\n  max-width: 760px;\n  color: var(--dsw-alias-label-primary);\n}\n\n.header {\n  display: flex;\n  align-items: center;\n  justify-content: flex-end;\n}\n\n.status,\n.failure p {\n  margin: 0;\n}\n\n.status,\n.failure {\n  font-size: 13px;\n  line-height: 20px;\n  color: var(--dsw-alias-label-tertiary);\n}\n\n.failure {\n  display: flex;\n  align-items: center;\n  gap: 10px;\n  color: var(--dsw-alias-state-error-primary);\n}\n\nbutton {\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 6px;\n  padding: 5px 12px;\n  background: transparent;\n  color: var(--dsw-alias-label-primary);\n  font: inherit;\n  font-size: 13px;\n  line-height: 20px;\n  cursor: pointer;\n}\n\nbutton:hover {\n  background: var(--dsw-alias-interactive-bg-hover);\n}\n\nbutton:focus-visible {\n  outline: 2px solid var(--dsw-alias-brand-primary);\n  outline-offset: 1px;\n}\n\nbutton:disabled {\n  cursor: not-allowed;\n  opacity: 0.55;\n}\n\n.primary {\n  border-color: var(--dsw-alias-button-primary-fill);\n  background: var(--dsw-alias-button-primary-fill);\n  color: var(--dsw-alias-label-primary-foreground);\n}\n\n.primary:hover {\n  background: var(--dsw-alias-button-primary-hover);\n}\n\n.list {\n  display: flex;\n  flex-direction: column;\n  gap: 8px;\n  margin: 0;\n  padding: 0;\n  list-style: none;\n}\n\n.row {\n  display: flex;\n  align-items: center;\n  justify-content: space-between;\n  gap: 12px;\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 10px;\n  padding: 10px 14px;\n  background: var(--dsw-alias-bg-layer-3);\n}\n\n.rowMain {\n  display: flex;\n  flex-direction: column;\n  gap: 4px;\n  min-width: 0;\n}\n\n.rowTitle {\n  display: flex;\n  align-items: center;\n  gap: 8px;\n  min-width: 0;\n}\n\n.serverName {\n  overflow: hidden;\n  font-size: 14px;\n  line-height: 20px;\n  font-weight: 600;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n}\n\n.badge {\n  display: inline-flex;\n  align-items: center;\n  min-height: 18px;\n  border-radius: 5px;\n  padding: 1px 6px;\n  font-size: 11px;\n  line-height: 16px;\n  white-space: nowrap;\n}\n\n.badge.mounting {\n  background: color-mix(in srgb, var(--dsw-alias-brand-primary) 12%, transparent);\n  color: var(--dsw-alias-brand-primary);\n}\n\n.badge.live {\n  background: color-mix(in srgb, var(--dsw-alias-state-success-primary) 12%, transparent);\n  color: var(--dsw-alias-state-success-primary);\n}\n\n.badge.failed {\n  background: color-mix(in srgb, var(--dsw-alias-state-error-primary) 12%, transparent);\n  color: var(--dsw-alias-state-error-primary);\n}\n\n.badge.stopped {\n  background: var(--dsw-alias-bg-layer-1);\n  color: var(--dsw-alias-label-tertiary);\n}\n\n.muted {\n  color: var(--dsw-alias-label-tertiary);\n}\n\n.rowMeta {\n  display: flex;\n  gap: 14px;\n  color: var(--dsw-alias-label-tertiary);\n  font-size: 12px;\n  line-height: 18px;\n  font-variant-numeric: tabular-nums;\n}\n\n.rowActions {\n  flex: none;\n}\n\n.card {\n  display: flex;\n  flex-direction: column;\n  gap: 0;\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 10px;\n  background: var(--dsw-alias-bg-layer-3);\n}\n\n.card > .row {\n  border: 0;\n  border-radius: 0;\n  background: transparent;\n}\n\n.modeRow {\n  display: flex;\n  align-items: center;\n  gap: 18px;\n  flex-wrap: wrap;\n  border: 1px solid var(--dsw-alias-border-l2);\n  border-radius: 10px;\n  padding: 8px 14px;\n  background: var(--dsw-alias-bg-layer-3);\n  font-size: 13px;\n  line-height: 20px;\n}\n\n.modeLabel {\n  font-weight: 600;\n}\n\n.modeOption {\n  display: inline-flex;\n  align-items: center;\n  gap: 6px;\n  cursor: pointer;\n}\n\n.modeHint {\n  margin: 0;\n  color: var(--dsw-alias-label-tertiary);\n  font-size: 12px;\n  line-height: 18px;\n}\n\n.toolPanel {\n  border-top: 1px solid var(--dsw-alias-border-l2);\n  padding: 10px 14px;\n}\n\n.toolGrid {\n  display: grid;\n  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));\n  gap: 4px 14px;\n  max-height: 320px;\n  overflow-y: auto;\n}\n\n.toolRow {\n  display: flex;\n  align-items: center;\n  gap: 8px;\n  min-width: 0;\n  padding: 2px 0;\n  font-size: 12px;\n  line-height: 18px;\n  cursor: pointer;\n}\n\n.toolName {\n  overflow: hidden;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n}\n";
+      style.setAttribute("data-file", "D:Gitclonedsh-mcp-manager-comparisonArvinQi__dsh-mcpsrcclientMcpSettingsSection.module.css");
+      style.textContent = ".section {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 14px;\r\n  width: 100%;\r\n  max-width: 760px;\r\n  color: var(--dsw-alias-label-primary);\r\n}\r\n\r\n.header {\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: flex-end;\r\n}\r\n\r\n.status,\r\n.failure p {\r\n  margin: 0;\r\n}\r\n\r\n.status,\r\n.failure {\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n  color: var(--dsw-alias-label-tertiary);\r\n}\r\n\r\n.failure {\r\n  display: flex;\r\n  align-items: center;\r\n  gap: 10px;\r\n  color: var(--dsw-alias-state-error-primary);\r\n}\r\n\r\nbutton {\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 6px;\r\n  padding: 5px 12px;\r\n  background: transparent;\r\n  color: var(--dsw-alias-label-primary);\r\n  font: inherit;\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n  cursor: pointer;\r\n}\r\n\r\nbutton:hover {\r\n  background: var(--dsw-alias-interactive-bg-hover);\r\n}\r\n\r\nbutton:focus-visible {\r\n  outline: 2px solid var(--dsw-alias-brand-primary);\r\n  outline-offset: 1px;\r\n}\r\n\r\nbutton:disabled {\r\n  cursor: not-allowed;\r\n  opacity: 0.55;\r\n}\r\n\r\n.primary {\r\n  border-color: var(--dsw-alias-button-primary-fill);\r\n  background: var(--dsw-alias-button-primary-fill);\r\n  color: var(--dsw-alias-label-primary-foreground);\r\n}\r\n\r\n.primary:hover {\r\n  background: var(--dsw-alias-button-primary-hover);\r\n}\r\n\r\n.list {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 8px;\r\n  margin: 0;\r\n  padding: 0;\r\n  list-style: none;\r\n}\r\n\r\n.row {\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: space-between;\r\n  gap: 12px;\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 10px;\r\n  padding: 10px 14px;\r\n  background: var(--dsw-alias-bg-layer-3);\r\n}\r\n\r\n.rowMain {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 4px;\r\n  min-width: 0;\r\n}\r\n\r\n.rowTitle {\r\n  display: flex;\r\n  align-items: center;\r\n  gap: 8px;\r\n  min-width: 0;\r\n}\r\n\r\n.serverName {\r\n  overflow: hidden;\r\n  font-size: 14px;\r\n  line-height: 20px;\r\n  font-weight: 600;\r\n  text-overflow: ellipsis;\r\n  white-space: nowrap;\r\n}\r\n\r\n.badge {\r\n  display: inline-flex;\r\n  align-items: center;\r\n  min-height: 18px;\r\n  border-radius: 5px;\r\n  padding: 1px 6px;\r\n  font-size: 11px;\r\n  line-height: 16px;\r\n  white-space: nowrap;\r\n}\r\n\r\n.badge.mounting {\r\n  background: color-mix(in srgb, var(--dsw-alias-brand-primary) 12%, transparent);\r\n  color: var(--dsw-alias-brand-primary);\r\n}\r\n\r\n.badge.live {\r\n  background: color-mix(in srgb, var(--dsw-alias-state-success-primary) 12%, transparent);\r\n  color: var(--dsw-alias-state-success-primary);\r\n}\r\n\r\n.badge.failed {\r\n  background: color-mix(in srgb, var(--dsw-alias-state-error-primary) 12%, transparent);\r\n  color: var(--dsw-alias-state-error-primary);\r\n}\r\n\r\n.badge.stopped {\r\n  background: var(--dsw-alias-bg-layer-1);\r\n  color: var(--dsw-alias-label-tertiary);\r\n}\r\n\r\n.muted {\r\n  color: var(--dsw-alias-label-tertiary);\r\n}\r\n\r\n.rowMeta {\r\n  display: flex;\r\n  gap: 14px;\r\n  color: var(--dsw-alias-label-tertiary);\r\n  font-size: 12px;\r\n  line-height: 18px;\r\n  font-variant-numeric: tabular-nums;\r\n}\r\n\r\n.rowActions {\r\n  flex: none;\r\n}\r\n\r\n.card {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 0;\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 10px;\r\n  background: var(--dsw-alias-bg-layer-3);\r\n}\r\n\r\n.card > .row {\r\n  border: 0;\r\n  border-radius: 0;\r\n  background: transparent;\r\n}\r\n\r\n.modeRow {\r\n  display: flex;\r\n  align-items: center;\r\n  gap: 18px;\r\n  flex-wrap: wrap;\r\n  border: 1px solid var(--dsw-alias-border-l2);\r\n  border-radius: 10px;\r\n  padding: 8px 14px;\r\n  background: var(--dsw-alias-bg-layer-3);\r\n  font-size: 13px;\r\n  line-height: 20px;\r\n}\r\n\r\n.modeLabel {\r\n  font-weight: 600;\r\n}\r\n\r\n.modeOption {\r\n  display: inline-flex;\r\n  align-items: center;\r\n  gap: 6px;\r\n  cursor: pointer;\r\n}\r\n\r\n.modeHint {\r\n  margin: 0;\r\n  color: var(--dsw-alias-label-tertiary);\r\n  font-size: 12px;\r\n  line-height: 18px;\r\n}\r\n\r\n.toolPanel {\r\n  border-top: 1px solid var(--dsw-alias-border-l2);\r\n  padding: 10px 14px;\r\n}\r\n\r\n.toolGrid {\r\n  display: grid;\r\n  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));\r\n  gap: 4px 14px;\r\n  max-height: 320px;\r\n  overflow-y: auto;\r\n}\r\n\r\n.toolRow {\r\n  display: flex;\r\n  align-items: center;\r\n  gap: 8px;\r\n  min-width: 0;\r\n  padding: 2px 0;\r\n  font-size: 12px;\r\n  line-height: 18px;\r\n  cursor: pointer;\r\n}\r\n\r\n.toolName {\r\n  overflow: hidden;\r\n  text-overflow: ellipsis;\r\n  white-space: nowrap;\r\n}\r\n";
       document.head.appendChild(style);
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ function validateServerInput(server, env) {
 	if (!serverNameSchema.safeParse(server.serverName).success) throw new McpServerValidationError("serverName must match [A-Za-z0-9_-]{1,32}");
 	if (server.transport === "stdio") {
 		if (server.command.trim().length === 0) throw new McpServerValidationError("stdio transport requires a command");
-		if (server.cwd.length > 0 && !/^[/\\]/.test(server.cwd)) throw new McpServerValidationError("cwd must be an absolute path or empty");
+		if (server.cwd.length > 0 && !/^(?:[A-Za-z]:[\\/]|[/\\])/.test(server.cwd)) throw new McpServerValidationError("cwd must be an absolute path or empty");
 	} else try {
 		const parsed = new URL(server.url);
 		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("non-http protocol");

--- a/src/client/ServerForm.tsx
+++ b/src/client/ServerForm.tsx
@@ -1,16 +1,16 @@
 import { useState, type ReactNode } from 'react'
-import type { McpServerId, McpServerView } from './types.ts'
+import type { McpManagerFailure, McpServerId, McpServerView } from './types.ts'
 import type {
   McpDraft, McpEnvRowDraft, McpTestOutcome,
 } from './mcp-store.ts'
-import { createEnvRowDraft, failureLocaleKey } from './mcp-store.ts'
+import { createEnvRowDraft } from './mcp-store.ts'
 import type { McpSettingsLocaleKey } from './locales.ts'
 import css from './ServerForm.module.css'
 
 /** The Remote verbs the editor needs; structurally the section's inject face. */
 export interface McpServerFormRemote {
-  save: (draft: McpDraft) => Promise<{ message: string } | null>
-  remove: (id: McpServerId) => Promise<{ message: string } | null>
+  save: (draft: McpDraft) => Promise<McpManagerFailure | null>
+  remove: (id: McpServerId) => Promise<McpManagerFailure | null>
   test: (draft: McpDraft) => Promise<McpTestOutcome>
   list: () => Promise<readonly McpServerView[]>
 }
@@ -60,13 +60,18 @@ export function McpServerForm(props: McpServerFormProps): ReactNode {
     update({ env: [...draft.env, createEnvRowDraft()] })
   }
 
+  const errorText = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error)
+
   const runTest = async (): Promise<void> => {
     setSaveError(null)
     actions.setTestRunning(true)
     try {
       actions.setTest(await injected.test(draft))
-    } catch {
+    } catch (error) {
+      console.error('[dsh-mcp] test failed:', error)
       actions.setTest(null)
+      setSaveError(errorText(error))
     } finally {
       actions.setTestRunning(false)
     }
@@ -78,14 +83,15 @@ export function McpServerForm(props: McpServerFormProps): ReactNode {
     try {
       const failure = await injected.save(draft)
       if (failure !== null) {
-        setSaveError(t(failureLocaleKey(failure.code)))
+        setSaveError(`${failure.code}: ${failure.message}`)
         return
       }
-      await refresh()
+      if (!await refresh()) return
       actions.cancelEdit()
       onSaved?.()
-    } catch {
-      setSaveError(t('failureTitle'))
+    } catch (error) {
+      console.error('[dsh-mcp] save failed:', error)
+      setSaveError(errorText(error))
     } finally {
       actions.setBusy(null)
     }
@@ -98,24 +104,27 @@ export function McpServerForm(props: McpServerFormProps): ReactNode {
     try {
       const failure = await injected.remove(draft.id)
       if (failure !== null) {
-        setSaveError(failure.message)
+        setSaveError(`${failure.code}: ${failure.message}`)
         return
       }
-      await refresh()
+      if (!await refresh()) return
       actions.cancelEdit()
-    } catch {
-      setSaveError(t('failureTitle'))
+    } catch (error) {
+      console.error('[dsh-mcp] remove failed:', error)
+      setSaveError(errorText(error))
     } finally {
       actions.setBusy(null)
     }
   }
 
-  const refresh = async (): Promise<void> => {
+  const refresh = async (): Promise<boolean> => {
     try {
       actions.setServers(await injected.list())
-    } catch {
-      // The save/remove outcome is the actionable one; a failed refresh is
-      // re-run on the next page visit.
+      return true
+    } catch (error) {
+      console.error('[dsh-mcp] refresh failed:', error)
+      setSaveError(errorText(error))
+      return false
     }
   }
 


### PR DESCRIPTION
## Summary

- accept drive-letter absolute paths for stdio MCP working directories
- preserve `refresh()` error handling while surfacing real Remote errors from save, refresh, test, and delete operations
- keep the checked-in browser bundle aligned with the TypeScript source

## Verification

- `node --check lib/index.js`
- `node --check lib/client.js`
- verified Windows drive-letter, POSIX, and UNC paths are accepted while relative paths are rejected