### PR TITLE
fix: preserve MCP image tool results

### DIFF
--- a/lib/mcp-client.js
+++ b/lib/mcp-client.js
@@ -6,7 +6,9 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { scrubbedParentEnv } from "@deepseek-ai/dsh-subprocess";
 import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import { z as z$1 } from "zod";
+import { isImageAdmissionError } from "@deepseek-ai/dsh-attachment";
 import { assertSupportedJsonSchema } from "@deepseek-ai/dsh-tools";
 //#region lib/types/transport.js
 /**
@@ -74,6 +76,15 @@ const INVALID_NAME_CHARS = /[^A-Za-z0-9_-]/g;
 const HASH_LENGTH = 12;
 /** Raw result record: the bridge owns JSON-value validation after transport. */
 const RawCallToolResultSchema = z$1.record(z$1.string(), z$1.unknown());
+/** Raster formats supported by the durable attachment vocabulary. */
+const IMAGE_MEDIA_TYPES = [
+	"image/png",
+	"image/jpeg",
+	"image/webp",
+	"image/gif"
+];
+/** Canonical RFC 4648 base64, excluding whitespace and URL-safe aliases. */
+const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 /** List without mutating the SDK's per-page output-validator cache. */
 function listToolsUncached(client, cursor) {
 	return client.request({
@@ -147,13 +158,7 @@ async function syncTools(client, ctx, opts, previous) {
 		for (const tool of response.tools) {
 			const publicName = publicToolName(opts.serverName, tool.name);
 			if (definitions.has(publicName)) throw new Error(`mcp-client(${opts.serverName}): server listed tool "${tool.name}" more than once — invalid tool list`);
-			definitions.set(publicName, {
-				name: publicName,
-				description: tool.description ?? "",
-				parameters: tool.inputSchema,
-				output: createOutput(tool.name, supportedOutputSchema(tool.outputSchema)),
-				execute: createExecutor(client, tool.name, tool.execution?.taskSupport === "required", opts)
-			});
+			definitions.set(publicName, createDefinition(client, ctx, publicName, tool.name, tool.description ?? "", tool.inputSchema, supportedOutputSchema(tool.outputSchema), tool.execution?.taskSupport === "required", opts));
 		}
 		cursor = response.nextCursor;
 	} while (cursor);
@@ -213,6 +218,26 @@ function supportedOutputSchema(candidate) {
 		return;
 	}
 }
+/** Build one tool definition with execution-local rich image projections. */
+function createDefinition(client, ctx, publicName, rawName, description, parameters, structuredSchema, taskRequired, opts) {
+	const projections = /* @__PURE__ */ new WeakMap();
+	return {
+		name: publicName,
+		description,
+		parameters,
+		output: createOutput(rawName, structuredSchema),
+		execute: createExecutor(client, ctx, rawName, taskRequired, opts, projections),
+		finalizeContent(exec, result) {
+			const projection = projections.get(exec);
+			if (projection === void 0) return void 0;
+			projections.delete(exec);
+			if (result.isError) return void 0;
+			if (!isDeepStrictEqual(result.value, projection.value)) return void 0;
+			if (!isDeepStrictEqual(result.content, projection.fallback)) return void 0;
+			return projection.content;
+		}
+	};
+}
 /** Build the canonical result schema and existing Native text projection. */
 function createOutput(rawName, structuredSchema) {
 	return {
@@ -246,7 +271,7 @@ function createOutput(rawName, structuredSchema) {
 * When the MCP server returns `isError: true`, the executor throws so that
 * the ToolRuntime's catch path produces an `isError` result for the model.
 */
-function createExecutor(client, rawName, taskRequired, opts) {
+function createExecutor(client, ctx, rawName, taskRequired, opts, projections) {
 	return async (args, exec) => {
 		if (taskRequired) throw new Error(`Tool "${rawName}" requires task-based execution, which this bridge does not support`);
 		const result = await callToolUncached(client, rawName, typeof args === "object" && args !== null ? args : {}, exec, opts);
@@ -265,10 +290,23 @@ function createExecutor(client, rawName, taskRequired, opts) {
 		const content = result.content;
 		const text = extractText(content, rawName);
 		if (result.isError === true) throw new Error(text);
-		return {
+		const value = {
 			content,
 			...result.structuredContent !== void 0 ? { structuredContent: result.structuredContent } : {}
 		};
+		if (containsImage(content)) {
+			const fallback = [{
+				type: "text",
+				text: extractText(content, rawName)
+			}];
+			const projected = await prepareImageProjection(ctx, exec, content, rawName);
+			projections.set(exec, {
+				value,
+				fallback,
+				content: projected
+			});
+		}
+		return value;
 	};
 }
 /**
@@ -279,32 +317,102 @@ function createExecutor(client, rawName, taskRequired, opts) {
 * Defensive: fields that the MCP spec declares required (mimeType, text) are
 * guarded with fallbacks because this is a network trust boundary.
 */
+function containsImage(content) {
+	return content.some((value) => isRecord(value) && value.type === "image");
+}
+function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function isImageMediaType(value) {
+	return IMAGE_MEDIA_TYPES.includes(value);
+}
+function decodeImage(block) {
+	if (block.mimeType === void 0 || !isImageMediaType(block.mimeType)) throw new Error("the declared media type is not PNG, JPEG, WebP, or GIF");
+	if (block.data === void 0 || !CANONICAL_BASE64.test(block.data)) throw new Error("the image data is not canonical base64");
+	const data = Buffer.from(block.data, "base64");
+	if (data.toString("base64") !== block.data) throw new Error("the image data is not canonical base64");
+	return { data, mediaType: block.mimeType };
+}
+async function resolveImageAdmission(ctx, exec) {
+	const attachments = ctx.get("attachments");
+	if (attachments === void 0) throw new Error("no attachment store is mounted");
+	const routed = exec.agent?.session.requestHeader()?.config;
+	const provider = routed?.provider ?? exec.agent?.options.provider;
+	const model = routed?.model ?? exec.agent?.options.model;
+	const llm = ctx.get("llm");
+	if (provider === void 0 || model === void 0 || llm === void 0) throw new Error("the current model route could not be resolved");
+	let info;
+	try {
+		info = await llm.resolveModelInfo(provider, model, exec.signal);
+	} catch {
+		throw new Error("the current model route could not be verified");
+	}
+	if (info.inputModalities === void 0 || !info.inputModalities.includes("image")) throw new Error(`model "${model}" does not declare image input`);
+	if (exec.signal.aborted) throw new Error("the tool call was canceled before image storage");
+	return attachments;
+}
+function imageDiagnostic(block, reason) {
+	return `[image unavailable: ${block.mimeType ?? "unknown media type"}; ${reason}; raw image data remains available to programmatic callers]`;
+}
+async function prepareImageProjection(ctx, exec, content, toolName) {
+	const decoded = [];
+	const validationErrors = /* @__PURE__ */ new Map();
+	const imageIndexes = [];
+	for (const [index, value] of content.entries()) {
+		if (!isRecord(value) || value.type !== "image") continue;
+		imageIndexes.push(index);
+		try {
+			decoded.push(decodeImage(value));
+		} catch (error) {
+			validationErrors.set(index, error.message);
+		}
+	}
+	if (validationErrors.size > 0) return projectContent(content, toolName, (block, index) => ({ type: "text", text: imageDiagnostic(block, validationErrors.get(index) ?? "another image in the same result was invalid") }));
+	let attachments;
+	try {
+		attachments = await resolveImageAdmission(ctx, exec);
+	} catch (error) {
+		return projectContent(content, toolName, (block) => ({ type: "text", text: imageDiagnostic(block, error.message) }));
+	}
+	try {
+		const refs = await attachments.saveImages(decoded);
+		const byIndex = new Map(imageIndexes.map((index, offset) => [index, refs[offset]]));
+		return projectContent(content, toolName, (_block, index) => ({ type: "image", attachment: byIndex.get(index) }));
+	} catch (error) {
+		const reason = isImageAdmissionError(error) ? `image admission rejected the result: ${error.message}` : "durable image storage rejected the result";
+		return projectContent(content, toolName, (block) => ({ type: "text", text: imageDiagnostic(block, reason) }));
+	}
+}
 function extractText(mcpContent, toolName) {
-	const parts = [];
-	for (const value of mcpContent) {
-		if (typeof value !== "object" || value === null || Array.isArray(value)) {
-			parts.push("[unsupported content type: unknown]");
+	return projectContent(mcpContent, toolName).map((block) => block.text).join("\n");
+}
+function projectContent(mcpContent, toolName, image = (block) => ({ type: "text", text: imageDiagnostic(block, "this result was not admitted to durable model context") })) {
+	const projected = [];
+	const text = [];
+	const flushText = () => {
+		if (text.length === 0) return;
+		projected.push({ type: "text", text: text.splice(0).join("\n") });
+	};
+	for (const [index, value] of mcpContent.entries()) {
+		if (!isRecord(value)) {
+			text.push("[unsupported MCP content block: expected an object]");
 			continue;
 		}
 		const block = value;
 		switch (block.type) {
-			case "text":
-				if (block.text !== void 0) parts.push(block.text);
-				break;
-			case "image":
-				parts.push(`[image: ${block.mimeType ?? "unknown"}, content discarded]`);
-				break;
-			case "audio":
-				parts.push(`[audio: ${block.mimeType ?? "unknown"}, content discarded]`);
-				break;
-			case "resource":
+			case "text": if (block.text !== void 0) text.push(block.text); break;
+			case "image": flushText(); projected.push(image(block, index)); break;
 			case "resource_link":
-				parts.push("[resource: content discarded]");
+				if (block.name === void 0 || block.uri === void 0) text.push("[resource link unavailable: the MCP block is missing its name or URI]");
+				else text.push(`Resource link: ${block.name} (${block.uri})`);
 				break;
-			default: parts.push(`[unsupported content type: ${block.type}]`);
+			case "audio": text.push(`[audio result unsupported: ${block.mimeType ?? "unknown media type"}; raw audio data remains available to programmatic callers]`); break;
+			case "resource": text.push("[embedded resource unsupported; raw resource data remains available to programmatic callers]"); break;
+			default: text.push(`[unsupported MCP content type: ${block.type}]`);
 		}
 	}
-	return parts.join("\n") || `(${toolName} returned no text content)`;
+	flushText();
+	return projected.length > 0 ? projected : [{ type: "text", text: `(${toolName} returned no model-visible content)` }];
 }
 //#endregion
 //#region lib/types/connection.js

--- a/lib/mcp-client.js
+++ b/lib/mcp-client.js
@@ -326,67 +326,90 @@ function isRecord(value) {
 function isImageMediaType(value) {
 	return IMAGE_MEDIA_TYPES.includes(value);
 }
+function decodedByteLength(base64) {
+	const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+	return base64.length / 4 * 3 - padding;
+}
+function imageDiagnostic(reason) {
+	return `[image unavailable: ${reason}; image bytes were not added to text context]`;
+}
+function preflightImages(content, limits) {
+	const images = [];
+	let totalBytes = 0;
+	for (const [index, value] of content.entries()) {
+		if (!isRecord(value) || value.type !== "image") continue;
+		if (value.mimeType === void 0 || !isImageMediaType(value.mimeType) || !limits.mediaTypes.includes(value.mimeType)) return { reason: "image type is not accepted" };
+		if (value.data === void 0 || !CANONICAL_BASE64.test(value.data)) return { reason: "invalid image data" };
+		const bytes = decodedByteLength(value.data);
+		if (bytes > limits.maxImageBytes) return { reason: "image exceeds the active size limit" };
+		totalBytes += bytes;
+		if (totalBytes > limits.maxMessageImageBytes) return { reason: "image batch exceeds the active size limit" };
+		images.push({ index, block: value });
+	}
+	if (images.length > limits.maxImagesPerMessage) return { reason: "image batch exceeds the active count limit" };
+	return { images };
+}
 function decodeImage(block) {
-	if (block.mimeType === void 0 || !isImageMediaType(block.mimeType)) throw new Error("the declared media type is not PNG, JPEG, WebP, or GIF");
-	if (block.data === void 0 || !CANONICAL_BASE64.test(block.data)) throw new Error("the image data is not canonical base64");
 	const data = Buffer.from(block.data, "base64");
-	if (data.toString("base64") !== block.data) throw new Error("the image data is not canonical base64");
+	if (data.toString("base64") !== block.data) throw new Error("invalid image data");
 	return { data, mediaType: block.mimeType };
 }
 async function resolveImageAdmission(ctx, exec) {
 	const attachments = ctx.get("attachments");
-	if (attachments === void 0) throw new Error("no attachment store is mounted");
+	if (attachments === void 0 || attachments.imageLimits === void 0) throw new Error("attachment store unavailable");
 	const routed = exec.agent?.session.requestHeader()?.config;
 	const provider = routed?.provider ?? exec.agent?.options.provider;
 	const model = routed?.model ?? exec.agent?.options.model;
 	const llm = ctx.get("llm");
-	if (provider === void 0 || model === void 0 || llm === void 0) throw new Error("the current model route could not be resolved");
+	if (provider === void 0 || model === void 0 || llm === void 0) throw new Error("model route unavailable");
 	let info;
 	try {
 		info = await llm.resolveModelInfo(provider, model, exec.signal);
 	} catch {
-		throw new Error("the current model route could not be verified");
+		throw new Error("model route unavailable");
 	}
-	if (info.inputModalities === void 0 || !info.inputModalities.includes("image")) throw new Error(`model "${model}" does not declare image input`);
-	if (exec.signal.aborted) throw new Error("the tool call was canceled before image storage");
+	if (info.inputModalities === void 0 || !info.inputModalities.includes("image")) throw new Error("model route is not image-capable");
+	if (exec.signal.aborted) throw new Error("tool call canceled");
 	return attachments;
 }
-function imageDiagnostic(block, reason) {
-	return `[image unavailable: ${block.mimeType ?? "unknown media type"}; ${reason}; raw image data remains available to programmatic callers]`;
+function admissionDiagnostic(error) {
+	switch (error?.code) {
+		case "TOO_MANY_IMAGES": return "image batch exceeds the active count limit";
+		case "IMAGES_TOO_LARGE":
+		case "IMAGE_TOO_LARGE": return "image exceeds the active size limit";
+		case "UNSUPPORTED_IMAGE_TYPE":
+		case "IMAGE_TYPE_MISMATCH": return "image type is not accepted";
+		default: return isImageAdmissionError(error) ? "invalid image data" : "image storage unavailable";
+	}
 }
 async function prepareImageProjection(ctx, exec, content, toolName) {
-	const decoded = [];
-	const validationErrors = /* @__PURE__ */ new Map();
-	const imageIndexes = [];
-	for (const [index, value] of content.entries()) {
-		if (!isRecord(value) || value.type !== "image") continue;
-		imageIndexes.push(index);
-		try {
-			decoded.push(decodeImage(value));
-		} catch (error) {
-			validationErrors.set(index, error.message);
-		}
-	}
-	if (validationErrors.size > 0) return projectContent(content, toolName, (block, index) => ({ type: "text", text: imageDiagnostic(block, validationErrors.get(index) ?? "another image in the same result was invalid") }));
 	let attachments;
 	try {
 		attachments = await resolveImageAdmission(ctx, exec);
 	} catch (error) {
-		return projectContent(content, toolName, (block) => ({ type: "text", text: imageDiagnostic(block, error.message) }));
+		const reason = error?.message === "model route is not image-capable" ? "model route is not image-capable" : error?.message === "tool call canceled" ? "tool call canceled" : error?.message === "attachment store unavailable" ? "attachment store unavailable" : "model route unavailable";
+		return projectContent(content, toolName, () => ({ type: "text", text: imageDiagnostic(reason) }));
+	}
+	const preflight = preflightImages(content, attachments.imageLimits);
+	if (preflight.reason !== void 0) return projectContent(content, toolName, () => ({ type: "text", text: imageDiagnostic(preflight.reason) }));
+	let decoded;
+	try {
+		decoded = preflight.images.map(({ block }) => decodeImage(block));
+	} catch {
+		return projectContent(content, toolName, () => ({ type: "text", text: imageDiagnostic("invalid image data") }));
 	}
 	try {
 		const refs = await attachments.saveImages(decoded);
-		const byIndex = new Map(imageIndexes.map((index, offset) => [index, refs[offset]]));
+		const byIndex = new Map(preflight.images.map(({ index }, offset) => [index, refs[offset]]));
 		return projectContent(content, toolName, (_block, index) => ({ type: "image", attachment: byIndex.get(index) }));
 	} catch (error) {
-		const reason = isImageAdmissionError(error) ? `image admission rejected the result: ${error.message}` : "durable image storage rejected the result";
-		return projectContent(content, toolName, (block) => ({ type: "text", text: imageDiagnostic(block, reason) }));
+		return projectContent(content, toolName, () => ({ type: "text", text: imageDiagnostic(admissionDiagnostic(error)) }));
 	}
 }
 function extractText(mcpContent, toolName) {
 	return projectContent(mcpContent, toolName).map((block) => block.text).join("\n");
 }
-function projectContent(mcpContent, toolName, image = (block) => ({ type: "text", text: imageDiagnostic(block, "this result was not admitted to durable model context") })) {
+function projectContent(mcpContent, toolName, image = () => ({ type: "text", text: imageDiagnostic("this result was not admitted to model image context") })) {
 	const projected = [];
 	const text = [];
 	const flushText = () => {
@@ -406,8 +429,8 @@ function projectContent(mcpContent, toolName, image = (block) => ({ type: "text"
 				if (block.name === void 0 || block.uri === void 0) text.push("[resource link unavailable: the MCP block is missing its name or URI]");
 				else text.push(`Resource link: ${block.name} (${block.uri})`);
 				break;
-			case "audio": text.push(`[audio result unsupported: ${block.mimeType ?? "unknown media type"}; raw audio data remains available to programmatic callers]`); break;
-			case "resource": text.push("[embedded resource unsupported; raw resource data remains available to programmatic callers]"); break;
+			case "audio": text.push("[audio result unsupported; audio bytes were not added to text context]"); break;
+			case "resource": text.push("[embedded resource unsupported; resource bytes were not added to text context]"); break;
 			default: text.push(`[unsupported MCP content type: ${block.type}]`);
 		}
 	}

--- a/test/mcp-image-projection.test.mjs
+++ b/test/mcp-image-projection.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 import test from "node:test";
 
 const bridgePath = new URL("../lib/mcp-client.js", import.meta.url);
@@ -10,15 +11,25 @@ async function loadImageProjection() {
 	assert.notEqual(toolsEnd, -1, "mcp-client tools module boundary must exist");
 	const toolsRegion = source.slice(0, toolsEnd);
 	const executable = toolsRegion.replace(/^import .*;\r?\n/gm, "");
-	const factory = new Function("Buffer", "isImageAdmissionError", `
+	const factory = new Function("Buffer", "isImageAdmissionError", "isDeepStrictEqual", `
 		const z$1 = { record: () => null, string: () => null, unknown: () => null };
 		const z = {};
 		const MAX_TIMER_DELAY_MS = 0;
 		const assertSupportedJsonSchema = () => {};
 		${executable}
-		return { decodeImage, prepareImageProjection, projectContent };
+		return { createDefinition, decodeImage, prepareImageProjection, projectContent };
 	`);
-	return factory(Buffer, () => false);
+	return factory(Buffer, () => false, isDeepStrictEqual);
+}
+
+function imageLimits(overrides = {}) {
+	return {
+		maxImageBytes: 8,
+		maxImagesPerMessage: 2,
+		maxMessageImageBytes: 12,
+		mediaTypes: ["image/png", "image/jpeg", "image/webp", "image/gif"],
+		...overrides
+	};
 }
 
 function createExec() {
@@ -38,6 +49,7 @@ function createExec() {
 test("projects admitted MCP images between adjacent text blocks", async () => {
 	const { prepareImageProjection } = await loadImageProjection();
 	const attachments = {
+		imageLimits: imageLimits(),
 		async saveImages(images) {
 			assert.equal(images.length, 1);
 			assert.equal(images[0].mediaType, "image/png");
@@ -65,12 +77,18 @@ test("projects admitted MCP images between adjacent text blocks", async () => {
 
 test("keeps invalid image data out of projected text", async () => {
 	const { prepareImageProjection } = await loadImageProjection();
-	const output = await prepareImageProjection({ get: () => undefined }, createExec(), [
+	const output = await prepareImageProjection({
+		get(name) {
+			if (name === "attachments") return { imageLimits: imageLimits(), saveImages: async () => ["unexpected"] };
+			if (name === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["image"] }) };
+			return undefined;
+		}
+	}, createExec(), [
 		{ type: "image", mimeType: "image/png", data: "not base64" }
 	], "camera");
 	assert.equal(output.length, 1);
 	assert.equal(output[0].type, "text");
-	assert.match(output[0].text, /image data is not canonical base64/);
+	assert.match(output[0].text, /invalid image data/);
 	assert.doesNotMatch(output[0].text, /not base64/);
 });
 
@@ -78,7 +96,7 @@ test("uses a diagnostic fallback when the routed model is not image-capable", as
 	const { prepareImageProjection } = await loadImageProjection();
 	const ctx = {
 		get(name) {
-			if (name === "attachments") return { saveImages: async () => ["unexpected"] };
+			if (name === "attachments") return { imageLimits: imageLimits(), saveImages: async () => ["unexpected"] };
 			if (name === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["text"] }) };
 			return undefined;
 		}
@@ -87,7 +105,7 @@ test("uses a diagnostic fallback when the routed model is not image-capable", as
 		{ type: "image", mimeType: "image/png", data: "AQ==" }
 	], "camera");
 	assert.equal(output[0].type, "text");
-	assert.match(output[0].text, /does not declare image input/);
+	assert.match(output[0].text, /model route is not image-capable/);
 	assert.doesNotMatch(output[0].text, /AQ==/);
 });
 
@@ -95,7 +113,7 @@ test("falls back safely when attachment storage rejects an image", async () => {
 	const { prepareImageProjection } = await loadImageProjection();
 	const ctx = {
 		get(name) {
-			if (name === "attachments") return { saveImages: async () => { throw new Error("storage unavailable"); } };
+			if (name === "attachments") return { imageLimits: imageLimits(), saveImages: async () => { throw new Error("storage unavailable"); } };
 			if (name === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["image"] }) };
 			return undefined;
 		}
@@ -104,7 +122,7 @@ test("falls back safely when attachment storage rejects an image", async () => {
 		{ type: "image", mimeType: "image/png", data: "AQ==" }
 	], "camera");
 	assert.equal(output[0].type, "text");
-	assert.match(output[0].text, /durable image storage rejected the result/);
+	assert.match(output[0].text, /image storage unavailable/);
 	assert.doesNotMatch(output[0].text, /AQ==/);
 });
 
@@ -116,7 +134,80 @@ test("keeps audio and resource fallbacks bounded", async () => {
 	], "multimedia");
 	assert.equal(output.length, 1);
 	assert.equal(output[0].type, "text");
-	assert.match(output[0].text, /audio result unsupported/);
-	assert.match(output[0].text, /embedded resource unsupported/);
+	assert.match(output[0].text, /audio bytes were not added to text context/);
+	assert.match(output[0].text, /resource bytes were not added to text context/);
 	assert.doesNotMatch(output[0].text, /raw-audio|raw-resource/);
+});
+
+test("preflights image byte, aggregate, and count limits before storage", async () => {
+	const { prepareImageProjection } = await loadImageProjection();
+	for (const [name, content, limits] of [
+		["single image", [{ type: "image", mimeType: "image/png", data: "AQIDBAUGBwg=" }], imageLimits({ maxImageBytes: 7 })],
+		["aggregate", [{ type: "image", mimeType: "image/png", data: "AQIDBAUG" }, { type: "image", mimeType: "image/png", data: "BwgJCgsM" }], imageLimits({ maxMessageImageBytes: 11 })],
+		["count", [{ type: "image", mimeType: "image/png", data: "AQ==" }, { type: "image", mimeType: "image/png", data: "Ag==" }], imageLimits({ maxImagesPerMessage: 1 })]
+	]) {
+		let saves = 0;
+		const ctx = {
+			get(key) {
+				if (key === "attachments") return { imageLimits: limits, saveImages: async () => { saves += 1; return []; } };
+				if (key === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["image"] }) };
+				return undefined;
+			}
+		};
+		const output = await prepareImageProjection(ctx, createExec(), content, name);
+		assert.equal(saves, 0, `${name} must not persist a preflight rejection`);
+		assert.match(output[0].text, /image bytes were not added to text context/);
+		for (const block of content) assert.doesNotMatch(output[0].text, new RegExp(block.data));
+	}
+});
+
+test("allows an exact image byte limit", async () => {
+	const { prepareImageProjection } = await loadImageProjection();
+	let saves = 0;
+	const ctx = {
+		get(key) {
+			if (key === "attachments") return { imageLimits: imageLimits({ maxImageBytes: 3, maxMessageImageBytes: 3 }), saveImages: async () => { saves += 1; return ["attachment-1"]; } };
+			if (key === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["image"] }) };
+			return undefined;
+		}
+	};
+	const output = await prepareImageProjection(ctx, createExec(), [{ type: "image", mimeType: "image/png", data: "AQID" }], "camera");
+	assert.equal(saves, 1);
+	assert.deepEqual(output, [{ type: "image", attachment: "attachment-1" }]);
+});
+
+test("finalizes only matching successful projections", async () => {
+	const { createDefinition } = await loadImageProjection();
+	const client = { request: async () => ({ content: [{ type: "image", mimeType: "image/png", data: "AQ==" }] }) };
+	const ctx = {
+		get(key) {
+			if (key === "attachments") return { imageLimits: imageLimits(), saveImages: async () => ["attachment-1"] };
+			if (key === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["image"] }) };
+			return undefined;
+		}
+	};
+	const definition = createDefinition(client, ctx, "mcp__srv__camera", "camera", "", { type: "object" }, undefined, false, { toolCallTimeoutMs: 1 });
+	const exec = createExec();
+	const value = await definition.execute({}, exec);
+	const fallback = definition.output.render({}, value);
+	assert.deepEqual(definition.finalizeContent(exec, { value, content: fallback, isError: false }), [{ type: "image", attachment: "attachment-1" }]);
+
+	const changedExec = createExec();
+	const changedValue = await definition.execute({}, changedExec);
+	const changedFallback = definition.output.render({}, changedValue);
+	assert.equal(definition.finalizeContent(changedExec, { value: { content: [] }, content: changedFallback, isError: false }), undefined);
+
+	const fallbackExec = createExec();
+	const fallbackValue = await definition.execute({}, fallbackExec);
+	assert.equal(definition.finalizeContent(fallbackExec, { value: fallbackValue, content: [{ type: "text", text: "changed" }], isError: false }), undefined);
+
+	const firstExec = createExec();
+	const secondExec = createExec();
+	const [firstValue, secondValue] = await Promise.all([definition.execute({}, firstExec), definition.execute({}, secondExec)]);
+	assert.deepEqual(definition.finalizeContent(firstExec, { value: firstValue, content: definition.output.render({}, firstValue), isError: false }), [{ type: "image", attachment: "attachment-1" }]);
+	assert.deepEqual(definition.finalizeContent(secondExec, { value: secondValue, content: definition.output.render({}, secondValue), isError: false }), [{ type: "image", attachment: "attachment-1" }]);
+
+	const errorExec = createExec();
+	const errorValue = await definition.execute({}, errorExec);
+	assert.equal(definition.finalizeContent(errorExec, { value: errorValue, content: definition.output.render({}, errorValue), isError: true }), undefined);
 });

--- a/test/mcp-image-projection.test.mjs
+++ b/test/mcp-image-projection.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const bridgePath = new URL("../lib/mcp-client.js", import.meta.url);
+
+async function loadImageProjection() {
+	const source = await readFile(bridgePath, "utf8");
+	const toolsEnd = source.search(/\/\/#endregion\r?\n\/\/#region lib\/types\/connection\.js/);
+	assert.notEqual(toolsEnd, -1, "mcp-client tools module boundary must exist");
+	const toolsRegion = source.slice(0, toolsEnd);
+	const executable = toolsRegion.replace(/^import .*;\r?\n/gm, "");
+	const factory = new Function("Buffer", "isImageAdmissionError", `
+		const z$1 = { record: () => null, string: () => null, unknown: () => null };
+		const z = {};
+		const MAX_TIMER_DELAY_MS = 0;
+		const assertSupportedJsonSchema = () => {};
+		${executable}
+		return { decodeImage, prepareImageProjection, projectContent };
+	`);
+	return factory(Buffer, () => false);
+}
+
+function createExec() {
+	return {
+		signal: new AbortController().signal,
+		agent: {
+			session: {
+				requestHeader() {
+					return { config: { provider: "test-provider", model: "vision-model" } };
+				}
+			},
+			options: {}
+		}
+	};
+}
+
+test("projects admitted MCP images between adjacent text blocks", async () => {
+	const { prepareImageProjection } = await loadImageProjection();
+	const attachments = {
+		async saveImages(images) {
+			assert.equal(images.length, 1);
+			assert.equal(images[0].mediaType, "image/png");
+			return ["attachment-1"];
+		}
+	};
+	const ctx = {
+		get(name) {
+			if (name === "attachments") return attachments;
+			if (name === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["text", "image"] }) };
+			return undefined;
+		}
+	};
+	const output = await prepareImageProjection(ctx, createExec(), [
+		{ type: "text", text: "before" },
+		{ type: "image", mimeType: "image/png", data: "AQ==" },
+		{ type: "text", text: "after" }
+	], "camera");
+	assert.deepEqual(output, [
+		{ type: "text", text: "before" },
+		{ type: "image", attachment: "attachment-1" },
+		{ type: "text", text: "after" }
+	]);
+});
+
+test("keeps invalid image data out of projected text", async () => {
+	const { prepareImageProjection } = await loadImageProjection();
+	const output = await prepareImageProjection({ get: () => undefined }, createExec(), [
+		{ type: "image", mimeType: "image/png", data: "not base64" }
+	], "camera");
+	assert.equal(output.length, 1);
+	assert.equal(output[0].type, "text");
+	assert.match(output[0].text, /image data is not canonical base64/);
+	assert.doesNotMatch(output[0].text, /not base64/);
+});
+
+test("uses a diagnostic fallback when the routed model is not image-capable", async () => {
+	const { prepareImageProjection } = await loadImageProjection();
+	const ctx = {
+		get(name) {
+			if (name === "attachments") return { saveImages: async () => ["unexpected"] };
+			if (name === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["text"] }) };
+			return undefined;
+		}
+	};
+	const output = await prepareImageProjection(ctx, createExec(), [
+		{ type: "image", mimeType: "image/png", data: "AQ==" }
+	], "camera");
+	assert.equal(output[0].type, "text");
+	assert.match(output[0].text, /does not declare image input/);
+	assert.doesNotMatch(output[0].text, /AQ==/);
+});

--- a/test/mcp-image-projection.test.mjs
+++ b/test/mcp-image-projection.test.mjs
@@ -90,3 +90,33 @@ test("uses a diagnostic fallback when the routed model is not image-capable", as
 	assert.match(output[0].text, /does not declare image input/);
 	assert.doesNotMatch(output[0].text, /AQ==/);
 });
+
+test("falls back safely when attachment storage rejects an image", async () => {
+	const { prepareImageProjection } = await loadImageProjection();
+	const ctx = {
+		get(name) {
+			if (name === "attachments") return { saveImages: async () => { throw new Error("storage unavailable"); } };
+			if (name === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["image"] }) };
+			return undefined;
+		}
+	};
+	const output = await prepareImageProjection(ctx, createExec(), [
+		{ type: "image", mimeType: "image/png", data: "AQ==" }
+	], "camera");
+	assert.equal(output[0].type, "text");
+	assert.match(output[0].text, /durable image storage rejected the result/);
+	assert.doesNotMatch(output[0].text, /AQ==/);
+});
+
+test("keeps audio and resource fallbacks bounded", async () => {
+	const { projectContent } = await loadImageProjection();
+	const output = projectContent([
+		{ type: "audio", mimeType: "audio/wav", data: "raw-audio" },
+		{ type: "resource", resource: { blob: "raw-resource" } }
+	], "multimedia");
+	assert.equal(output.length, 1);
+	assert.equal(output[0].type, "text");
+	assert.match(output[0].text, /audio result unsupported/);
+	assert.match(output[0].text, /embedded resource unsupported/);
+	assert.doesNotMatch(output[0].text, /raw-audio|raw-resource/);
+});


### PR DESCRIPTION
## Summary

- port the official attachment-backed MCP image projection into the vendored dsh-mcp bridge
- validate supported image media types and canonical Base64 before attachment storage
- admit images only for models that declare image input, while preserving ordered text/image results
- keep invalid images, attachment failures, audio, and resource blocks on bounded text fallbacks
- add focused regression coverage for successful projection and fallback paths

## Validation

- `node --test test/mcp-image-projection.test.mjs`
- `node --check lib/mcp-client.js`
- `node --check test/mcp-image-projection.test.mjs`
- `git diff --check`

The change is based on upstream `main` at `c0cd61f` and is intended to restore native model-visible image content for Open Computer Use and other MCP image results without emitting image Base64 as text.