### PR TITLE
fix: report MCP image admission failures precisely

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      # Zero-dependency package: no install needed, syntax smoke only.
+      # Zero-dependency package: run focused regression tests and syntax smoke checks.
+      - run: npm test
       - run: node --check lib/index.js
       - run: node --check lib/client.js
       - run: node --check scripts/build.mjs

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OAuth token exchange failed with `code, code_verifier, client_id, redirect_uri are required`**: when the client was loaded from persistence the in-memory closure was null, so the token request lacked `client_id`. The exchange now reads client info and code verifier through the provider accessors (memory first, persistence fallback)
 - **OAuth concurrent authorization port collision**: with a stable callback port, a mount and a test connection authorizing at the same time collided on the port (EADDRINUSE). Authorization flows are now serialized per server
 - **Env-variable secret values were not persisted**: the editor dropped the value for secret rows. Filled values are now submitted (secret values go to the credentials document); a blank value keeps the stored one
+- **MCP image admission diagnostics no longer misreport failures**: distinguish image count, batch/per-image byte, MIME, Base64, raster, decoded-pixel, and maximum-dimension limits; unknown admission errors use a fixed diagnostic so valid-but-oversized images are not reported as invalid image data and attachment storage internals are not leaked
 
 ## [1.4.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - **OAuth token 交换报 `code, code_verifier, client_id, redirect_uri are required`**：client 从持久化读取时内存闭包为 null，token 请求缺 `client_id`。修复：exchange 改用 provider 访问器（内存优先、持久化回退）
 - **OAuth 并发授权端口冲突**：回调端口稳定后，挂载与测试连接同时授权会抢同一端口（EADDRINUSE）。修复：同服务器授权流程串行化
 - **环境变量 secret 值未写入凭据**：编辑器保存 secret 行时丢弃了值。修复：填写值即提交（secret 写入凭据文档），留空保留原值
+- **MCP 图片 admission 诊断不再误报**：区分图片数量、批量/单图字节数、MIME 类型、Base64、图片格式、解码像素数和最大边长限制；未知 admission 错误使用固定诊断，避免把有效但超尺寸的图片误报为无效图片数据，也不泄露 attachment 存储内部错误
 
 ## [1.4.0] - 2026-08-16
 

--- a/lib/mcp-client.js
+++ b/lib/mcp-client.js
@@ -375,11 +375,15 @@ async function resolveImageAdmission(ctx, exec) {
 function admissionDiagnostic(error) {
 	switch (error?.code) {
 		case "TOO_MANY_IMAGES": return "image batch exceeds the active count limit";
-		case "IMAGES_TOO_LARGE":
+		case "IMAGES_TOO_LARGE": return "image batch exceeds the active size limit";
 		case "IMAGE_TOO_LARGE": return "image exceeds the active size limit";
-		case "UNSUPPORTED_IMAGE_TYPE":
-		case "IMAGE_TYPE_MISMATCH": return "image type is not accepted";
-		default: return isImageAdmissionError(error) ? "invalid image data" : "image storage unavailable";
+		case "UNSUPPORTED_IMAGE_TYPE": return "image type is not accepted";
+		case "IMAGE_TYPE_MISMATCH": return "declared image type does not match image bytes";
+		case "INVALID_IMAGE_BASE64": return "invalid image Base64";
+		case "INVALID_IMAGE": return "malformed or unsupported image data";
+		case "IMAGE_TOO_MANY_PIXELS": return "image exceeds the decoded-pixel limit";
+		case "IMAGE_DIMENSION_TOO_LARGE": return "image exceeds the maximum side dimension";
+		default: return isImageAdmissionError(error) ? "image admission failed" : "image storage unavailable";
 	}
 }
 async function prepareImageProjection(ctx, exec, content, toolName) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "node scripts/build.mjs"
+    "build": "node scripts/build.mjs",
+    "test": "node --test test/mcp-image-projection.test.mjs"
   },
   "author": "Arvin.qi <arvin.qi@qq.com>",
   "license": "MIT",

--- a/test/mcp-image-projection.test.mjs
+++ b/test/mcp-image-projection.test.mjs
@@ -17,9 +17,9 @@ async function loadImageProjection() {
 		const MAX_TIMER_DELAY_MS = 0;
 		const assertSupportedJsonSchema = () => {};
 		${executable}
-		return { createDefinition, decodeImage, prepareImageProjection, projectContent };
+		return { createDefinition, decodeImage, prepareImageProjection, projectContent, admissionDiagnostic };
 	`);
-	return factory(Buffer, () => false, isDeepStrictEqual);
+	return factory(Buffer, (error) => error?.code !== undefined, isDeepStrictEqual);
 }
 
 function imageLimits(overrides = {}) {
@@ -210,4 +210,42 @@ test("finalizes only matching successful projections", async () => {
 	const errorExec = createExec();
 	const errorValue = await definition.execute({}, errorExec);
 	assert.equal(definition.finalizeContent(errorExec, { value: errorValue, content: definition.output.render({}, errorValue), isError: true }), undefined);
+});
+
+test("maps attachment admission codes to bounded diagnostics", async () => {
+	const { admissionDiagnostic } = await loadImageProjection();
+	const cases = [
+		["TOO_MANY_IMAGES", "image batch exceeds the active count limit"],
+		["IMAGES_TOO_LARGE", "image batch exceeds the active size limit"],
+		["IMAGE_TOO_LARGE", "image exceeds the active size limit"],
+		["UNSUPPORTED_IMAGE_TYPE", "image type is not accepted"],
+		["IMAGE_TYPE_MISMATCH", "declared image type does not match image bytes"],
+		["INVALID_IMAGE_BASE64", "invalid image Base64"],
+		["INVALID_IMAGE", "malformed or unsupported image data"],
+		["IMAGE_TOO_MANY_PIXELS", "image exceeds the decoded-pixel limit"],
+		["IMAGE_DIMENSION_TOO_LARGE", "image exceeds the maximum side dimension"]
+	];
+	for (const [code, reason] of cases) assert.equal(admissionDiagnostic({ code }), reason, code);
+	assert.equal(admissionDiagnostic(new Error("storage secret")), "image storage unavailable");
+});
+
+test("projects dimension admission failures without leaking storage details", async () => {
+	const { prepareImageProjection } = await loadImageProjection();
+	const output = await prepareImageProjection({
+		get(name) {
+			if (name === "attachments") return {
+				imageLimits: imageLimits(),
+				async saveImages() {
+					throw Object.assign(new Error("private attachment path"), { code: "IMAGE_DIMENSION_TOO_LARGE" });
+				}
+			};
+			if (name === "llm") return { resolveModelInfo: async () => ({ inputModalities: ["image"] }) };
+			return undefined;
+		}
+	}, createExec(), [
+		{ type: "image", mimeType: "image/png", data: "AQ==" }
+	], "camera");
+	assert.equal(output.length, 1);
+	assert.match(output[0].text, /maximum side dimension/);
+	assert.doesNotMatch(output[0].text, /private attachment path/);
 });


### PR DESCRIPTION
## Summary

- Preserve ordered MCP image blocks as durable attachments while keeping model-facing text fallbacks bounded.
- Map attachment admission codes to precise, non-leaking diagnostics instead of collapsing valid-but-rejected images into `invalid image data`.
- Add regression coverage for count, byte, MIME, Base64, raster, decoded-pixel, and maximum-dimension admission failures.
- Add a standard `test` script, run the focused tests in the publish workflow, and document the fix in both changelogs.

## Root Cause

The MCP image payload can be valid and within byte/pixel limits while being rejected by the attachment store's maximum side-dimension policy. The bridge previously reported such admission failures as generic invalid image data, obscuring the actual deployment policy rejection.

## Validation

- `pnpm test` (10 passing)
- `node --check lib/index.js`
- `node --check lib/client.js`
- `node --check lib/mcp-client.js`
- `node --check scripts/build.mjs`
- `git diff --check`

The client bundle build still requires a DSH source checkout containing esbuild, as documented by `scripts/build.mjs`; the current environment has only the production DSH install and no source checkout. No client bundle source was changed in this PR.
